### PR TITLE
reprogram dropdown area algorithm

### DIFF
--- a/example/pages/demo-ajusting-position.tsx
+++ b/example/pages/demo-ajusting-position.tsx
@@ -13,7 +13,7 @@ let DemoAjustingPosition: FC<{}> = React.memo((props) => {
       <DocDemo title="Detect edge">
         <DocBlock content={contentEdge} />
         <DocSnippet code={codeEdge} />
-        <DropdownArea guessHeight={80} className={cx(styleTrigger)} width={400} renderContent={(onClose) => "Some content"} hideClose>
+        <DropdownArea className={cx(styleTrigger)} width={400} renderContent={(onClose) => "Some content"} hideClose>
           <div>detect edge</div>
         </DropdownArea>
       </DocDemo>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/dropdown",
-  "version": "0.1.34",
+  "version": "0.1.35-a1",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/dropdown",
-  "version": "0.1.35-a1",
+  "version": "0.1.35-a2",
   "description": "",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/dropdown-menu.tsx
+++ b/src/dropdown-menu.tsx
@@ -206,6 +206,7 @@ let styleSearchIcon = css`
   font-size: 23px;
   right: 15px;
   top: 13px;
+  line-height: 23px;
   color: hsla(0, 0%, 59%, 1);
 `;
 


### PR DESCRIPTION
之前的方案是点击打开菜单的时候快速计算一个位置, 然后开启 `adjustPosition` 的话, 会再出发一次位置调整. 这个计算规则效果不够好.

目前的方案是等到卡片展示出来之后, 再通过已经得到的卡片的宽度和高度进行较为准确的计算. 卡片最大高度是 360px, 尽量保持卡片可见, 其次保证触发元素可见, 最终不行的话还是会挡住触发位置, 卡片放在 bottom:8px 这样一个位置.
